### PR TITLE
Add utility: poe-port-bounce.py

### DIFF
--- a/utility/poe-port-bounce/README.md
+++ b/utility/poe-port-bounce/README.md
@@ -2,7 +2,13 @@
 
 Have you ever needed to reset a PoE device that you couldn't (or just didn't want to) physically touch to pop the cable out and plug back in?
 
-You could disable poe on a port, commit and then roll back, and that's essentially what this script does.
+You could disable poe on a port, commit and then roll back, and that's essentially what this script does. After disabling and committing, the script executes a "rollback 1" and commits a 2nd time.
+
+# Compatibility
+
+I've tested this on my EX2300-C VC at home, as well as a couple of other models, like EX3400 and EX4300. The Junos syntax hasn't changed on other similar platforms like EX4100/4400, so this shouldn't have any issue working on those as well.
+
+# Examples
 
 Example: bounce port ge-0/0/29 on the switch closet13.mycompany.net, using the username jdoe, with SSH key authentication.
 
@@ -16,5 +22,3 @@ Example: bounce port ge-0/0/1 on labsw1.mycompany.net, using the username/passwo
 poe-port-bounce.py --sys labsw1.mycompany.net --port ge-0/0/1 \
     --user jdoe --password abc123
 ```
-
-Upon execution, the script will disable poe on the port provided, commit the config, then immediately execute a "rollback 1" and commit again.

--- a/utility/poe-port-bounce/README.md
+++ b/utility/poe-port-bounce/README.md
@@ -1,0 +1,20 @@
+## PoE Port Bounce Utility
+
+Have you ever needed to reset a PoE device that you couldn't (or just didn't want to) physically touch to pop the cable out and plug back in?
+
+You could disable poe on a port, commit and then roll back, and that's essentially what this script does.
+
+Example: bounce port ge-0/0/29 on the switch closet13.mycompany.net, using the username jdoe, with SSH key authentication.
+
+```
+poe-port-bounce.py --sys closet13.mycompany.net --port ge-0/0/29 --user jdoe
+```
+
+Example: bounce port ge-0/0/1 on labsw1.mycompany.net, using the username/password jdoe/abc123.
+
+```
+poe-port-bounce.py --sys labsw1.mycompany.net --port ge-0/0/1 \
+    --user jdoe --password abc123
+```
+
+Upon execution, the script will disable poe on the port provided, commit the config, then immediately execute a "rollback 1" and commit again.

--- a/utility/poe-port-bounce/poe-port-bounce.py
+++ b/utility/poe-port-bounce/poe-port-bounce.py
@@ -1,0 +1,70 @@
+#!/usr/bin/env python3
+
+"""
+You ever need to bounce a port on a system, but don't
+want to, or just plain can't walk up to the system
+and pull a cable out? Don't feel like doing the
+disable/commit/enable/commit dance manually?
+This does the work for you.
+
+Yes, you could also drop to a root shell and
+use ifconfig, but JTAC doesn't exactly look
+fondly on that. So don't do that. Plus, "unexpected"
+consequences could occur from that, and who likes those?
+
+The only non-default module here is PyEZ. Installation
+directions for the module found here:
+https://github.com/Juniper/py-junos-eznc
+"""
+
+import argparse
+import os
+import logging
+from jnpr.junos import Device
+from jnpr.junos.utils.config import Config
+
+# Setup logger
+LOG_LEVEL = 'ERROR'
+logging.basicConfig(level=LOG_LEVEL,
+                    format='[%(asctime)s] %(message)s')
+logger = logging.getLogger()
+
+parser = argparse.ArgumentParser(
+    description='Juniper Device Port Bounce Utility'
+)
+
+parser.add_argument('--sys', action="store")
+parser.add_argument('--port', action="store")
+parser.add_argument('--user', action="store",
+                    default=os.getenv('USER'),
+                    help="Will default to your current username.")
+parser.add_argument('--password', action="store",
+                    help="Omit this option if you're using ssh keys to authenticate")  # noqa: E501
+args = parser.parse_args()
+
+
+def main():
+    disable_command = f"set interfaces {args.port} disable"
+    disable_comment = f"shut port {args.port}"
+    rollback_comment = f"rollback shut of port {args.port}"
+
+    dev = Device(host=args.sys, user=args.user, password=args.password)
+    logger.error(f"Connecting to: {args.sys}")
+    dev.open()
+    dev.bind(cu=Config)
+    logger.error(f"Locking the configuration on: {args.sys}")
+    dev.cu.lock()
+    logger.error(f"Now shutting port: {args.port}")
+    dev.cu.load(disable_command, format='set')
+    dev.cu.commit(comment=disable_comment, timeout=180)
+    logger.error(f"Now executing rollback on: {args.sys}")
+    dev.cu.rollback(rb_id=1)
+    dev.cu.commit(comment=rollback_comment, timeout=180)
+    logger.error(f"Unlocking the configuration on: {args.sys}")
+    dev.cu.unlock()
+    dev.close()
+    logger.error("Done!")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Add poe-port-bounce.py tool to the utility folder. Target use case is creating a simple one-liner to cut poe to a specific port, commit, rollback, and commit again.